### PR TITLE
chore: comment out provably dead code (reversible DEADCODE markers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The root **`Dockerfile`** automates this: Node stage builds the client into `ser
 
 ## API / routing
 
-- **Controllers:** `server/Api/Controllers/` (`Api.Controllers` and related namespaces). Routes use attributes such as `[Route("[controller]/[action]")]`; **`GlobalApiRoutePrefixConvention`** in `server/Api/Program.cs` prepends **`api`** to each controller’s attribute route template, so typical controller routes are under **`/api/...`**.
+- **Controllers:** `server/Api/Controllers/` (`Api.Controllers` and related namespaces). Routes use attributes such as `[Route("[controller]/[action]")]`; the **`api`** prefix is prepended by **`ApplicationConfigurations.ConfigureApi`** from SeliseBlocks.Genesis.OS (its default `apiRoutePrefix`), so typical controller routes are under **`/api/...`**. (A local `GlobalApiRoutePrefixConvention` class existed for the same purpose but was never registered; it is commented out pending removal.)
 - **Swagger:** `Program.cs` registers Swagger UI (e.g. **`/swagger`**, JSON at **`/swagger/v1/swagger.json`**).
 - **Static SPA:** `UseDefaultFiles`, `UseStaticFiles`, and when `wwwroot/index.html` exists, **`MapFallbackToFile("/index.html")`** for client-side routing.
 - **Further middleware and endpoints** are applied in **`ApplicationConfigurations.ConfigureMiddleware`** from **SeliseBlocks.Genesis.OS** (referenced via domain packages); use Swagger against a running instance for a complete list beyond this repo’s `Program.cs`.

--- a/client/app/components/filter-toolbar/index.type.ts
+++ b/client/app/components/filter-toolbar/index.type.ts
@@ -1,0 +1,2 @@
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+

--- a/client/app/components/info-tool-tip/index.ts
+++ b/client/app/components/info-tool-tip/index.ts
@@ -1,0 +1,2 @@
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+

--- a/client/app/components/ui-kits/calendar/calendar/calendar.tsx
+++ b/client/app/components/ui-kits/calendar/calendar/calendar.tsx
@@ -1,58 +1,59 @@
-
-import * as React from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { DayPicker } from "react-day-picker";
-
-import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui-kits/button/button";
-
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
-
-function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
-  return (
-    <DayPicker
-      showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
-      classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
-        nav_button: cn(
-          buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
-        ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
-        head_row: "flex",
-        head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-        day: cn(
-          buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
-        ),
-        day_range_end: "day-range-end",
-        day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside:
-          "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
-        day_disabled: "text-muted-foreground opacity-50",
-        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
-        ...classNames,
-      }}
-      components={{
-        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
-        IconRight: () => <ChevronRight className="h-4 w-4" />,
-      }}
-      {...props}
-    />
-  );
-}
-Calendar.displayName = "Calendar";
-
-export { Calendar };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+//
+// import * as React from "react";
+// import { ChevronLeft, ChevronRight } from "lucide-react";
+// import { DayPicker } from "react-day-picker";
+//
+// import { cn } from "@/lib/utils";
+// import { buttonVariants } from "@/components/ui-kits/button/button";
+//
+// export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+//
+// function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+//   return (
+//     <DayPicker
+//       showOutsideDays={showOutsideDays}
+//       className={cn("p-3", className)}
+//       classNames={{
+//         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+//         month: "space-y-4",
+//         caption: "flex justify-center pt-1 relative items-center",
+//         caption_label: "text-sm font-medium",
+//         nav: "space-x-1 flex items-center",
+//         nav_button: cn(
+//           buttonVariants({ variant: "outline" }),
+//           "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+//         ),
+//         nav_button_previous: "absolute left-1",
+//         nav_button_next: "absolute right-1",
+//         table: "w-full border-collapse space-y-1",
+//         head_row: "flex",
+//         head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+//         row: "flex w-full mt-2",
+//         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+//         day: cn(
+//           buttonVariants({ variant: "ghost" }),
+//           "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+//         ),
+//         day_range_end: "day-range-end",
+//         day_selected:
+//           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+//         day_today: "bg-accent text-accent-foreground",
+//         day_outside:
+//           "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
+//         day_disabled: "text-muted-foreground opacity-50",
+//         day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
+//         day_hidden: "invisible",
+//         ...classNames,
+//       }}
+//       components={{
+//         IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+//         IconRight: () => <ChevronRight className="h-4 w-4" />,
+//       }}
+//       {...props}
+//     />
+//   );
+// }
+// Calendar.displayName = "Calendar";
+//
+// export { Calendar };

--- a/client/app/components/ui-kits/collapsible/collapsible/collapsible.tsx
+++ b/client/app/components/ui-kits/collapsible/collapsible/collapsible.tsx
@@ -1,10 +1,11 @@
-
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
-
-const Collapsible = CollapsiblePrimitive.Root
-
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
-
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
-
-export { Collapsible, CollapsibleTrigger, CollapsibleContent }
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+//
+// import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+//
+// const Collapsible = CollapsiblePrimitive.Root
+//
+// const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+//
+// const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+//
+// export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/client/app/components/ui-kits/hover-card/hover-card.tsx
+++ b/client/app/components/ui-kits/hover-card/hover-card.tsx
@@ -1,29 +1,30 @@
-
-
-import * as React from "react"
-import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
-
-import { cn } from "@/lib/utils"
-
-const HoverCard = HoverCardPrimitive.Root
-
-const HoverCardTrigger = HoverCardPrimitive.Trigger
-
-const HoverCardContent = React.forwardRef<
-  React.ElementRef<typeof HoverCardPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
-))
-HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
-
-export { HoverCard, HoverCardTrigger, HoverCardContent }
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+//
+//
+// import * as React from "react"
+// import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+//
+// import { cn } from "@/lib/utils"
+//
+// const HoverCard = HoverCardPrimitive.Root
+//
+// const HoverCardTrigger = HoverCardPrimitive.Trigger
+//
+// const HoverCardContent = React.forwardRef<
+//   React.ElementRef<typeof HoverCardPrimitive.Content>,
+//   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+// >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+//   <HoverCardPrimitive.Content
+//     ref={ref}
+//     align={align}
+//     sideOffset={sideOffset}
+//     className={cn(
+//       "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+//       className
+//     )}
+//     {...props}
+//   />
+// ))
+// HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+//
+// export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/client/app/components/ui-kits/spinner-loader/spinner-loader.tsx
+++ b/client/app/components/ui-kits/spinner-loader/spinner-loader.tsx
@@ -1,14 +1,15 @@
-import React from "react";
-
-const SpinnerLoader = () => {
-  return (
-    <div
-      className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent"
-      role="status"
-    >
-      <span className="sr-only">Loading...</span>
-    </div>
-  );
-};
-
-export default SpinnerLoader;
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import React from "react";
+//
+// const SpinnerLoader = () => {
+//   return (
+//     <div
+//       className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent"
+//       role="status"
+//     >
+//       <span className="sr-only">Loading...</span>
+//     </div>
+//   );
+// };
+//
+// export default SpinnerLoader;

--- a/client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/specification-option.tsx
+++ b/client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/specification-option.tsx
@@ -1,25 +1,26 @@
-export const SpecificationOption = ({
-  ram,
-  cpu,
-  bandwidth,
-  isSelected,
-  onClick,
-}: {
-  ram: string;
-  cpu: string;
-  bandwidth: string;
-  id: string;
-  isSelected: boolean;
-  onClick: () => void;
-}) => (
-  <button
-    onClick={onClick}
-    className={`rounded-lg border p-4 text-left transition-colors ${
-      isSelected ? "border-primary" : "border-default bg-background hover:bg-secondary"
-    }`}
-  >
-    <div className="text-lg font-semibold">{cpu} CPU</div>
-    <div className="text-sm">{ram} RAM</div>
-    <div className="text-sm">{bandwidth} Bandwidth</div>
-  </button>
-);
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// export const SpecificationOption = ({
+//   ram,
+//   cpu,
+//   bandwidth,
+//   isSelected,
+//   onClick,
+// }: {
+//   ram: string;
+//   cpu: string;
+//   bandwidth: string;
+//   id: string;
+//   isSelected: boolean;
+//   onClick: () => void;
+// }) => (
+//   <button
+//     onClick={onClick}
+//     className={`rounded-lg border p-4 text-left transition-colors ${
+//       isSelected ? "border-primary" : "border-default bg-background hover:bg-secondary"
+//     }`}
+//   >
+//     <div className="text-lg font-semibold">{cpu} CPU</div>
+//     <div className="text-sm">{ram} RAM</div>
+//     <div className="text-sm">{bandwidth} Bandwidth</div>
+//   </button>
+// );

--- a/client/app/cross-modules/deployment/constants/health.constant.ts
+++ b/client/app/cross-modules/deployment/constants/health.constant.ts
@@ -1,7 +1,8 @@
-export const TABS = {
-  all: { label: "All services", monitorSourceType: undefined },
-  services: { label: "Blocks services", monitorSourceType: 2 },
-  deployed: { label: "Deployed services", monitorSourceType: 1 },
-  external: { label: "My services", monitorSourceType: 3 },
-} as const;
-export type TabKey = keyof typeof TABS;
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// export const TABS = {
+//   all: { label: "All services", monitorSourceType: undefined },
+//   services: { label: "Blocks services", monitorSourceType: 2 },
+//   deployed: { label: "Deployed services", monitorSourceType: 1 },
+//   external: { label: "My services", monitorSourceType: 3 },
+// } as const;
+// export type TabKey = keyof typeof TABS;

--- a/client/app/cross-modules/deployment/models/mock-data.ts
+++ b/client/app/cross-modules/deployment/models/mock-data.ts
@@ -1,0 +1,2 @@
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+

--- a/client/app/layouts/console-layout/console-layout.tsx
+++ b/client/app/layouts/console-layout/console-layout.tsx
@@ -1,32 +1,33 @@
-import { Outlet, Link } from "react-router";
-import { Logo } from "@/components/logo";
-import { ModeToggle } from "@/components/mode-toggle/mode-toggle";
-import { Notification } from "@blocks-communication/components/notification/notification";
-import { BlocksAppLauncher } from "@/components/blocks-app-launcher/blocks-app-launcher";
-import { UserDropdownMenu } from "@/components/user-dropdown-menu/user-dropdown-menu";
-
-// Auth/impersonation guards are applied by the router (blocks-kit
-// AuthResolver/ProtectedGuard/ImpersonationChecker/ImpersonationTerminator);
-// this layout is purely the console chrome.
-export function ConsoleLayout() {
-  return (
-    <div className="relative min-h-screen bg-[hsl(var(--surface-app))]">
-      <div className="fixed left-0 right-0 top-0 z-40 border-b bg-background">
-        <header className="mx-5 flex h-12 items-center justify-between gap-4 sm:mx-10 lg:h-[59px]">
-          <Link to="/app/console" className="cursor-pointer">
-            <Logo width={96} height={32} className="h-8 w-auto" />
-          </Link>
-          <div className="flex items-center gap-4">
-            <ModeToggle />
-            <Notification />
-            <BlocksAppLauncher />
-            <UserDropdownMenu />
-          </div>
-        </header>
-      </div>
-      <main className="pt-[59px]">
-        <Outlet />
-      </main>
-    </div>
-  );
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { Outlet, Link } from "react-router";
+// import { Logo } from "@/components/logo";
+// import { ModeToggle } from "@/components/mode-toggle/mode-toggle";
+// import { Notification } from "@blocks-communication/components/notification/notification";
+// import { BlocksAppLauncher } from "@/components/blocks-app-launcher/blocks-app-launcher";
+// import { UserDropdownMenu } from "@/components/user-dropdown-menu/user-dropdown-menu";
+//
+// // Auth/impersonation guards are applied by the router (blocks-kit
+// // AuthResolver/ProtectedGuard/ImpersonationChecker/ImpersonationTerminator);
+// // this layout is purely the console chrome.
+// export function ConsoleLayout() {
+//   return (
+//     <div className="relative min-h-screen bg-[hsl(var(--surface-app))]">
+//       <div className="fixed left-0 right-0 top-0 z-40 border-b bg-background">
+//         <header className="mx-5 flex h-12 items-center justify-between gap-4 sm:mx-10 lg:h-[59px]">
+//           <Link to="/app/console" className="cursor-pointer">
+//             <Logo width={96} height={32} className="h-8 w-auto" />
+//           </Link>
+//           <div className="flex items-center gap-4">
+//             <ModeToggle />
+//             <Notification />
+//             <BlocksAppLauncher />
+//             <UserDropdownMenu />
+//           </div>
+//         </header>
+//       </div>
+//       <main className="pt-[59px]">
+//         <Outlet />
+//       </main>
+//     </div>
+//   );
+// }

--- a/client/app/layouts/dashboard-header/dashboard-header.tsx
+++ b/client/app/layouts/dashboard-header/dashboard-header.tsx
@@ -1,63 +1,64 @@
-import { BackToConsoleNavigator } from "@/components/back-to-console-navigator";
-import { Button } from "@/components/ui-kits/button/button";
-import { Notification } from "@blocks-communication/components/notification/notification";
-import { SidebarContext } from "@/contexts/dashboard-layout-provider";
-import { SidebarMobileView } from "@/layouts/sidebar-mobile-view/sidebar-mobile-view";
-import { cn } from "@/lib/utils";
-import { useProjectStore } from "@/store/project.store.ts";
-import { AppSwitcher, ThemeSwitcher, UserDropdownMenu } from "@seliseblocks/genesis-os";
-import { ChevronRight, FolderOpen, PanelLeft } from "lucide-react";
-import { useContext } from "react";
-import { useLocation } from "react-router";
-
-
-export function DashboardHeader() {
-  const { isSidebarOpen, toggleSidebar } = useContext(SidebarContext);
-  const { pathname } = useLocation();
-  const { selectedProject } = useProjectStore();
-  const projectName = selectedProject?.name;
-  const environment = selectedProject?.environment;
-  const isProjectOverviewRoute = pathname.startsWith("/app/project-overview");
-  return (
-    <>
-      <header className="flex h-[60px] items-center justify-between gap-4 border-b bg-background px-5 sm:px-6">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="md:hidden">
-            <SidebarMobileView />
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn("hidden shrink-0 p-0", !isSidebarOpen && "md:inline-flex")}
-            onClick={toggleSidebar}
-          >
-            <PanelLeft className="h-6 w-6" />
-          </Button>
-          {!isProjectOverviewRoute && !isSidebarOpen && (projectName || environment) && (
-            <div className="hidden min-w-0 items-center gap-1.5 md:flex">
-              <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              {projectName && (
-                <span className="truncate text-sm font-medium text-foreground">{projectName}</span>
-              )}
-              {projectName && environment && (
-                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              )}
-              {environment && (
-                <span className="rounded-sm bg-[hsl(var(--blocks-primary-50))] px-1.5 py-0.5 text-[11px] font-semibold text-[hsl(var(--high-emphasis))]">
-                  {environment}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-        <div className="flex items-center gap-4">
-          <BackToConsoleNavigator />
-          <ThemeSwitcher />
-          <Notification />
-          <AppSwitcher forwardedTo="/app/dashboard" />
-          <UserDropdownMenu />
-        </div>
-      </header>
-    </>
-  );
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { BackToConsoleNavigator } from "@/components/back-to-console-navigator";
+// import { Button } from "@/components/ui-kits/button/button";
+// import { Notification } from "@blocks-communication/components/notification/notification";
+// import { SidebarContext } from "@/contexts/dashboard-layout-provider";
+// import { SidebarMobileView } from "@/layouts/sidebar-mobile-view/sidebar-mobile-view";
+// import { cn } from "@/lib/utils";
+// import { useProjectStore } from "@/store/project.store.ts";
+// import { AppSwitcher, ThemeSwitcher, UserDropdownMenu } from "@seliseblocks/genesis-os";
+// import { ChevronRight, FolderOpen, PanelLeft } from "lucide-react";
+// import { useContext } from "react";
+// import { useLocation } from "react-router";
+//
+//
+// export function DashboardHeader() {
+//   const { isSidebarOpen, toggleSidebar } = useContext(SidebarContext);
+//   const { pathname } = useLocation();
+//   const { selectedProject } = useProjectStore();
+//   const projectName = selectedProject?.name;
+//   const environment = selectedProject?.environment;
+//   const isProjectOverviewRoute = pathname.startsWith("/app/project-overview");
+//   return (
+//     <>
+//       <header className="flex h-[60px] items-center justify-between gap-4 border-b bg-background px-5 sm:px-6">
+//         <div className="flex min-w-0 items-center gap-3">
+//           <div className="md:hidden">
+//             <SidebarMobileView />
+//           </div>
+//           <Button
+//             variant="ghost"
+//             size="icon"
+//             className={cn("hidden shrink-0 p-0", !isSidebarOpen && "md:inline-flex")}
+//             onClick={toggleSidebar}
+//           >
+//             <PanelLeft className="h-6 w-6" />
+//           </Button>
+//           {!isProjectOverviewRoute && !isSidebarOpen && (projectName || environment) && (
+//             <div className="hidden min-w-0 items-center gap-1.5 md:flex">
+//               <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+//               {projectName && (
+//                 <span className="truncate text-sm font-medium text-foreground">{projectName}</span>
+//               )}
+//               {projectName && environment && (
+//                 <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+//               )}
+//               {environment && (
+//                 <span className="rounded-sm bg-[hsl(var(--blocks-primary-50))] px-1.5 py-0.5 text-[11px] font-semibold text-[hsl(var(--high-emphasis))]">
+//                   {environment}
+//                 </span>
+//               )}
+//             </div>
+//           )}
+//         </div>
+//         <div className="flex items-center gap-4">
+//           <BackToConsoleNavigator />
+//           <ThemeSwitcher />
+//           <Notification />
+//           <AppSwitcher forwardedTo="/app/dashboard" />
+//           <UserDropdownMenu />
+//         </div>
+//       </header>
+//     </>
+//   );
+// }

--- a/client/app/layouts/dashboard-layout/dashboard-layout.tsx
+++ b/client/app/layouts/dashboard-layout/dashboard-layout.tsx
@@ -1,26 +1,27 @@
-import { ErrorBoundary } from "@/components/error-boundary";
-import { DashboardLayoutProvider } from "@/contexts/dashboard-layout-provider";
-import { DashboardHeader } from "@/layouts/dashboard-header/dashboard-header";
-import { SidebarMenuDesktop } from "@/layouts/sidebar-menu-desktop/sidebar-menu-desktop";
-import { Outlet } from "react-router";
-
-// Auth/impersonation guards are applied by the router (blocks-kit
-// AuthResolver/ProtectedGuard/ImpersonationChecker/ImpersonationSynchronizer);
-// this layout is purely the dashboard chrome.
-export function DashboardLayout() {
-  return (
-    <DashboardLayoutProvider isOpen={true} persist>
-      <div className="relative flex h-screen overflow-hidden bg-[hsl(var(--surface-app))]">
-        <SidebarMenuDesktop />
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <DashboardHeader />
-          <main className="flex-1 overflow-y-auto overflow-x-hidden">
-            <ErrorBoundary>
-              <Outlet />
-            </ErrorBoundary>
-          </main>
-        </div>
-      </div>
-    </DashboardLayoutProvider>
-  );
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { ErrorBoundary } from "@/components/error-boundary";
+// import { DashboardLayoutProvider } from "@/contexts/dashboard-layout-provider";
+// import { DashboardHeader } from "@/layouts/dashboard-header/dashboard-header";
+// import { SidebarMenuDesktop } from "@/layouts/sidebar-menu-desktop/sidebar-menu-desktop";
+// import { Outlet } from "react-router";
+//
+// // Auth/impersonation guards are applied by the router (blocks-kit
+// // AuthResolver/ProtectedGuard/ImpersonationChecker/ImpersonationSynchronizer);
+// // this layout is purely the dashboard chrome.
+// export function DashboardLayout() {
+//   return (
+//     <DashboardLayoutProvider isOpen={true} persist>
+//       <div className="relative flex h-screen overflow-hidden bg-[hsl(var(--surface-app))]">
+//         <SidebarMenuDesktop />
+//         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+//           <DashboardHeader />
+//           <main className="flex-1 overflow-y-auto overflow-x-hidden">
+//             <ErrorBoundary>
+//               <Outlet />
+//             </ErrorBoundary>
+//           </main>
+//         </div>
+//       </div>
+//     </DashboardLayoutProvider>
+//   );
+// }

--- a/client/app/layouts/project-overview-layout.tsx
+++ b/client/app/layouts/project-overview-layout.tsx
@@ -1,22 +1,23 @@
-import { Outlet } from "react-router";
-import { DashboardLayoutProvider } from "@/contexts/dashboard-layout-provider";
-import { DashboardHeader } from "@/layouts/dashboard-header/dashboard-header";
-import { SidebarMenuDesktop } from "@/layouts/sidebar-menu-desktop/sidebar-menu-desktop";
-
-// Mirrors the uds ProjectOverviewLayout: reuses deployment's existing dashboard
-// chrome (sidebar + header) and renders the nested project-overview routes.
-export function ProjectOverviewLayout() {
-  return (
-    <DashboardLayoutProvider isOpen={true} persist>
-      <div className="relative flex h-screen overflow-hidden bg-[hsl(var(--surface-app))]">
-        <SidebarMenuDesktop />
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <DashboardHeader />
-          <main className="flex-1 overflow-y-auto overflow-x-hidden">
-            <Outlet />
-          </main>
-        </div>
-      </div>
-    </DashboardLayoutProvider>
-  );
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { Outlet } from "react-router";
+// import { DashboardLayoutProvider } from "@/contexts/dashboard-layout-provider";
+// import { DashboardHeader } from "@/layouts/dashboard-header/dashboard-header";
+// import { SidebarMenuDesktop } from "@/layouts/sidebar-menu-desktop/sidebar-menu-desktop";
+//
+// // Mirrors the uds ProjectOverviewLayout: reuses deployment's existing dashboard
+// // chrome (sidebar + header) and renders the nested project-overview routes.
+// export function ProjectOverviewLayout() {
+//   return (
+//     <DashboardLayoutProvider isOpen={true} persist>
+//       <div className="relative flex h-screen overflow-hidden bg-[hsl(var(--surface-app))]">
+//         <SidebarMenuDesktop />
+//         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+//           <DashboardHeader />
+//           <main className="flex-1 overflow-y-auto overflow-x-hidden">
+//             <Outlet />
+//           </main>
+//         </div>
+//       </div>
+//     </DashboardLayoutProvider>
+//   );
+// }

--- a/client/app/store/user.store.ts
+++ b/client/app/store/user.store.ts
@@ -1,22 +1,23 @@
-import { User } from "@blocks-idp/iam/models/user";
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
-
-interface UserState {
-  user: User | null;
-  setUser: (user: User | null) => void;
-  reset: () => void;
-}
-
-export const useUserStore = create<UserState>()(
-  persist(
-    (set) => ({
-      user: null,
-      setUser: (user: User | null) => set((state) => ({ ...state, user })),
-      reset: () => set((state) => ({ ...state, user: null })),
-    }),
-    {
-      name: "user-storage",
-    },
-  ),
-);
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { User } from "@blocks-idp/iam/models/user";
+// import { create } from "zustand";
+// import { persist } from "zustand/middleware";
+//
+// interface UserState {
+//   user: User | null;
+//   setUser: (user: User | null) => void;
+//   reset: () => void;
+// }
+//
+// export const useUserStore = create<UserState>()(
+//   persist(
+//     (set) => ({
+//       user: null,
+//       setUser: (user: User | null) => set((state) => ({ ...state, user })),
+//       reset: () => set((state) => ({ ...state, user: null })),
+//     }),
+//     {
+//       name: "user-storage",
+//     },
+//   ),
+// );

--- a/client/app/utils/breadcrumb.util.ts
+++ b/client/app/utils/breadcrumb.util.ts
@@ -1,6 +1,7 @@
-import { BREADCRUMB_CUSTOM_TITLES } from "@/constants/breadcrumb-custom-title.constant";
-import type { RouterType } from "@/router";
-
-export function clearBreadCrumbTitleEntry(pathName: RouterType) {
-  BREADCRUMB_CUSTOM_TITLES[pathName] = null;
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { BREADCRUMB_CUSTOM_TITLES } from "@/constants/breadcrumb-custom-title.constant";
+// import type { RouterType } from "@/router";
+//
+// export function clearBreadCrumbTitleEntry(pathName: RouterType) {
+//   BREADCRUMB_CUSTOM_TITLES[pathName] = null;
+// }

--- a/server/Api/GlobalApiRoutePrefixConvention.cs
+++ b/server/Api/GlobalApiRoutePrefixConvention.cs
@@ -1,26 +1,27 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApplicationModels;
-
-namespace BlocksTemplate.Api;
-
-/// <summary>Prepends a segment (e.g. <c>api</c>) to every controller’s attribute route template.</summary>
-internal sealed class GlobalApiRoutePrefixConvention(string routeTemplate) : IApplicationModelConvention
-{
-    private readonly AttributeRouteModel _prefix = new(new RouteAttribute(routeTemplate));
-
-    public void Apply(ApplicationModel application)
-    {
-        foreach (var controller in application.Controllers)
-        {
-            foreach (var selector in controller.Selectors)
-            {
-                if (selector.AttributeRouteModel != null)
-                {
-                    selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(
-                        _prefix,
-                        selector.AttributeRouteModel);
-                }
-            }
-        }
-    }
-}
+// DEADCODE 2026-07-29: type(s) unreferenced anywhere in server or XUnitTest; whole file commented pending review
+// using Microsoft.AspNetCore.Mvc;
+// using Microsoft.AspNetCore.Mvc.ApplicationModels;
+//
+// namespace BlocksTemplate.Api;
+//
+// /// <summary>Prepends a segment (e.g. <c>api</c>) to every controller’s attribute route template.</summary>
+// internal sealed class GlobalApiRoutePrefixConvention(string routeTemplate) : IApplicationModelConvention
+// {
+//     private readonly AttributeRouteModel _prefix = new(new RouteAttribute(routeTemplate));
+//
+//     public void Apply(ApplicationModel application)
+//     {
+//         foreach (var controller in application.Controllers)
+//         {
+//             foreach (var selector in controller.Selectors)
+//             {
+//                 if (selector.AttributeRouteModel != null)
+//                 {
+//                     selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(
+//                         _prefix,
+//                         selector.AttributeRouteModel);
+//                 }
+//             }
+//         }
+//     }
+// }


### PR DESCRIPTION
## Dead code pass (comment-only, fully reversible)

Every change is a comment-out with a `// DEADCODE 2026-07-29` marker on the first line. No file deleted, no live code modified. Restoring a file means deleting the marker line and stripping the leading `// ` from each line; byte-level reversibility was verified for every client file against its previous git blob.

Verification on this exact tree:
- Client: `npm run build` succeeded; Vitest 122 files / 664 tests, all passed (suite rerun after the final file set was in place).
- Server: `dotnet build` of Api and Worker both succeeded with 0 errors; XUnitTest 386 of 386 passed.
- E2E: the suite is one spec file with two tests; 1 passed, 1 failed, and the failure is identical on the clean baseline (proven by stashing this diff and rerunning `tests/deployment/deployment.spec.ts`: same 1 failed / 1 passed at the same line). The failure is against the shared dev environment and pre-exists this change; this diff does not change the e2e result set.

Method: knip over the client (router is static, no `React.lazy`, no `import.meta.glob`; `routes.test.tsx` dynamically imports only the live routes index), then independent grep re-verification of every candidate including all `@blocks-*` aliases (including `@blocks-deployment`) and the vitest-only genesis-os stub aliases, then reduction to an import-closed set. Backend: all 24 controller actions plus the SignalR hub were enumerated (route = genesis `api` prefix + attribute template; the local convention class turns out never registered) and grepped against this repo's client and e2e, then against every sibling repo.

### A. Commented out (16 files)

Client, unreachable from `main.tsx` / the router tree (13 files):
- `client/app/components/filter-toolbar/index.type.ts`
- `client/app/components/info-tool-tip/index.ts` (barrel nothing imports)
- `client/app/components/ui-kits/calendar/calendar/calendar.tsx` (duplicate nested copy; `calendar/calendar.tsx` is the live one)
- `client/app/components/ui-kits/collapsible/collapsible/collapsible.tsx` (duplicate nested copy)
- `client/app/components/ui-kits/hover-card/hover-card.tsx`
- `client/app/components/ui-kits/spinner-loader/spinner-loader.tsx`
- `client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/specification-option.tsx`
- `client/app/cross-modules/deployment/constants/health.constant.ts`
- `client/app/cross-modules/deployment/models/mock-data.ts`
- `client/app/layouts/console-layout/console-layout.tsx`, `client/app/layouts/dashboard-header/dashboard-header.tsx`, `client/app/layouts/dashboard-layout/dashboard-layout.tsx`, `client/app/layouts/project-overview-layout.tsx` (the app shell now comes from the `@seliseblocks/genesis-os` package pages; these local layouts have no importer)

Client, unreferenced store/util (2 files):
- `client/app/store/user.store.ts`
- `client/app/utils/breadcrumb.util.ts`

Server (1 file):
- `server/Api/GlobalApiRoutePrefixConvention.cs`: never registered anywhere; the `api` route prefix actually comes from the genesis `ApplicationConfigurations.ConfigureApi` default. The class is `internal sealed`, so only the Api assembly could reference it, and nothing does. The routing paragraph in `README.md` claimed this convention was applied in `Program.cs` (stale before this PR); that sentence is corrected in this PR to credit `ConfigureApi` and note the commented class.

### B. Candidates left for review (NOT commented)

Endpoints: none are dead. Zero-client-hit actions and their status:
- `GET /api/Auth/TestPing`: consumed cross-repo by blocks-os `DomainManagementService.cs:183`.
- `POST /api/Build/repo-update`: consumed by six sibling clients (identifier project services in localization, iam, studio, utilities, agents, data).
- `POST /api/DeploymentHubBroadcast/broadcast`: internal Worker-to-API fan-out (`HttpDeploymentHubService.cs:16`).
- `DELETE /api/Auth/DeleteAuthorization`: test-referenced, and SDK-shaped (the shipped `SeliseBlocks.ReleaseDriver.OS` driver exposes a parallel `DeleteAuthorizationAsync` consumed by blocks-logic); listed only.
- `GET /api/Github/clone` and `GET /api/Github/CreateWebhook`: test-referenced, devops/admin-setup shaped; listed only.
- `POST /api/Github/webhook`: external GitHub webhook receiver (payload URL registered from vault config); zero client hits by design.

Server:
- `server/Worker/Consumers/PostProjectCreateConsumer.cs`: implements `IConsumer<Tenant>` but is never registered in `Worker/Program.cs` (only PostBuildConsumer and LogNotificationConsumer are), and genesis's `RoutingTable` maps only DI-registered consumers, so it is provably inert. Left uncommented because it looks like a MISSING REGISTRATION rather than dead code: it initiates data-gateway instance creation on project create, which someone probably intends to happen. Needs a product decision: register it or retire it.
- `Devops.DomainService` zero-reference models (`RepoWithBuildResponse.cs`, `GithubAddWebhookResponse.cs` with its filename/type mismatch, `CreateGithubWebhookRequest.cs`): the project's DLL is packed into the shipped `SeliseBlocks.ReleaseDriver.OS` NuGet package, so these are public package surface; untouchable in this pass.
- Client endpoint constants referencing routes that do not exist on this server (Monitor/*, Health/*, `auth/removeAccessToken`, `build/build`, `build/repos`): reverse orphans worth a follow-up ticket.

Client:
- `client/app/test-utils/stubs/blocks-kit*.tsx|ts` (5 files): flagged by knip but they are the vitest stub aliases for `@seliseblocks/genesis-os` (`vitest.config.ts:14-29`), and `blocks-kit-stores.ts` is imported by two of the live stubs; live test infrastructure.
- Unused dependencies per knip (dependency changes out of scope): `@beefree.io/sdk`, `@hcaptcha/react-hcaptcha`, `@mailupinc/bee-plugin`, `@radix-ui/react-alert-dialog`, `@radix-ui/react-hover-card`, `jwt-decode`, `react-qr-code`, `recharts`, `uuid`; dev: `@types/uuid`, `lint-staged`. Several appear copy-pasted across the Blocks clients and deserve one dedicated dependency-pruning pass.
- 65 unused named exports inside live files; left as no-touch.
