### PR TITLE
fix(deployment): use runtime env for monitor base URL

### DIFF
--- a/client/app/cross-modules/deployment/components/alert/alert.tsx
+++ b/client/app/cross-modules/deployment/components/alert/alert.tsx
@@ -5,6 +5,7 @@ import { useProjectStore } from "@/store/project.store";
 import { useDeploymentStatus } from "@blocks-deployment/components/deployment-details/shared/notification-listener";
 import { ExternalLink } from "lucide-react";
 import { AlertsList } from "./alerts-list";
+import { getRuntimeEnv } from "@/lib/runtime-env";
 
 const Alert = ({
   repoId,
@@ -31,9 +32,10 @@ const Alert = ({
           <div className="flex h-10 items-center justify-end gap-4 rounded text-base">
             <Button
               onClick={() =>
-                window.open(
-                  "http://dev-observability.blocksdevelopers.com/health",
+               window.open(
+                  `${getRuntimeEnv("BLOCKS_MONITOR_BASE_URL")}`,
                   "_blank",
+                  "noopener,noreferrer",
                 )
               }
               className="h-9 gap-2"


### PR DESCRIPTION
Replace the hardcoded observability URL with BLOCKS_MONITOR_BASE_URL and open the link with noopener,noreferrer.