### PR TITLE
[#175] Paginate the repo-details response

### DIFF
--- a/client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/deployment-settings-modal.test.tsx
+++ b/client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/deployment-settings-modal.test.tsx
@@ -136,4 +136,38 @@ describe("DeploymentSettingsModal", () => {
     );
     expect(navigateMock).toHaveBeenCalled();
   });
+
+  // ─── Pagination (#175) ──────────────────────────────────────────────────────
+
+  // This modal is mounted even while closed and always calls useGetRepoDetails, so once
+  // the query key carries paging it would issue a SECOND request alongside the page's.
+  // Forwarding the caller's paging keeps both on one cache entry. The modal reads only
+  // data.repo, so which page it asks for is immaterial to it.
+  it("forwards the paging it was given so it shares the caller's query", () => {
+    renderWithProviders(
+      <DeploymentSettingsModal
+        isOpen
+        onClose={vi.fn()}
+        repoId="r1"
+        pageNumber={1}
+        pageSize={1}
+      />,
+    );
+
+    expect(useGetRepoDetails).toHaveBeenCalledWith("r1", {
+      pageNumber: 1,
+      pageSize: 1,
+    });
+  });
+
+  it("falls back to the endpoint's own defaults when given no paging", () => {
+    renderWithProviders(
+      <DeploymentSettingsModal isOpen onClose={vi.fn()} repoId="r1" />,
+    );
+
+    expect(useGetRepoDetails).toHaveBeenCalledWith("r1", {
+      pageNumber: 1,
+      pageSize: 30,
+    });
+  });
 });

--- a/client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/deployment-settings-modal.tsx
+++ b/client/app/cross-modules/deployment/components/deployment-details/deployment-settings-modal/deployment-settings-modal.tsx
@@ -36,6 +36,11 @@ interface IDeploymentSettingsModalProps {
   isDeploymentFlow?: boolean;
   onDeploy?: (deploymentData: DeploymentFormData) => void;
   isDeploying?: boolean;
+  /** Mirrors the caller's paging so both share one cached repo-details query instead of
+   *  issuing a second request. This modal only reads `data.repo`. Defaults match the
+   *  endpoint's own defaults for callers that do not paginate. */
+  pageNumber?: number;
+  pageSize?: number;
 }
 
 const DeploymentSettingsModal = ({
@@ -45,6 +50,8 @@ const DeploymentSettingsModal = ({
   isDeploymentFlow = false,
   onDeploy,
   isDeploying = false,
+  pageNumber = 1,
+  pageSize = 30,
 }: IDeploymentSettingsModalProps) => {
   const navigate = useNavigate();
   const scoped = useScopedPath();
@@ -80,7 +87,7 @@ const DeploymentSettingsModal = ({
     data: repoDetails,
     isError,
     error,
-  } = useGetRepoDetails(repoId);
+  } = useGetRepoDetails(repoId, { pageNumber, pageSize });
   const { data: specs, isLoading: isSpecsLoading } = useGetSpecs() as any;
   const { mutate: updateRepoSettings, isPending } = useUpdateRepoSettings({
     onSuccess: () => {

--- a/client/app/cross-modules/deployment/hooks/use-github-info.test.ts
+++ b/client/app/cross-modules/deployment/hooks/use-github-info.test.ts
@@ -1,5 +1,7 @@
 import { createWrapper } from "@/test-utils/test-providers/query-client";
 import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import {
   mockRepository,
@@ -344,6 +346,105 @@ describe("Github Info Hooks", () => {
       expect(githubInfoService.getRepoDetails).toHaveBeenCalledWith(
         MOCK_REPO_ID,
       );
+    });
+
+    // H5/H6
+    it("forwards branch and paging to the service", async () => {
+      vi.mocked(githubInfoService.getRepoDetails).mockResolvedValue({} as any);
+
+      const { result } = renderHook(
+        () =>
+          useGetRepoDetails(MOCK_REPO_ID, {
+            branch: "develop",
+            pageNumber: 1,
+            pageSize: 1,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(githubInfoService.getRepoDetails).toHaveBeenCalledWith(MOCK_REPO_ID, {
+        branch: "develop",
+        pageNumber: 1,
+        pageSize: 1,
+      });
+    });
+
+    // H5: paging must produce a distinct cache entry, so a different page size fetches
+    // again rather than reading the previous page's data.
+    it("caches each page size separately", async () => {
+      vi.mocked(githubInfoService.getRepoDetails).mockResolvedValue({} as any);
+      const wrapper = createWrapper();
+
+      const one = renderHook(
+        () => useGetRepoDetails(MOCK_REPO_ID, { pageNumber: 1, pageSize: 1 }),
+        { wrapper },
+      );
+      await waitFor(() => expect(one.result.current.isSuccess).toBe(true));
+
+      const thirty = renderHook(
+        () => useGetRepoDetails(MOCK_REPO_ID, { pageNumber: 1, pageSize: 30 }),
+        { wrapper },
+      );
+      await waitFor(() => expect(thirty.result.current.isSuccess).toBe(true));
+
+      expect(githubInfoService.getRepoDetails).toHaveBeenCalledTimes(2);
+    });
+
+    // H5: the must-not-break requirement. ["repo-details", repoId] has to stay a usable
+    // invalidation prefix, which is why repoId keeps second position in the tuple. This
+    // asserts the behaviour (a refetch happens) rather than comparing key arrays, since a
+    // key that merely looks right can still fail prefix matching.
+    it("still refetches when invalidated by the repoId prefix alone", async () => {
+      vi.mocked(githubInfoService.getRepoDetails).mockResolvedValue({} as any);
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+      const { result } = renderHook(
+        () =>
+          useGetRepoDetails(MOCK_REPO_ID, {
+            branch: "develop",
+            pageNumber: 1,
+            pageSize: 1,
+          }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(githubInfoService.getRepoDetails).toHaveBeenCalledTimes(1);
+
+      await queryClient.invalidateQueries({
+        queryKey: ["repo-details", MOCK_REPO_ID],
+      });
+
+      await waitFor(() =>
+        expect(githubInfoService.getRepoDetails).toHaveBeenCalledTimes(2),
+      );
+    });
+
+    // C1: null and empty are tested independently, because the criterion names both.
+    it("makes no request for an empty repoId", async () => {
+      vi.mocked(githubInfoService.getRepoDetails).mockResolvedValue({} as any);
+
+      renderHook(() => useGetRepoDetails(""), { wrapper: createWrapper() });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(githubInfoService.getRepoDetails).not.toHaveBeenCalled();
+    });
+
+    it("makes no request for a null repoId", async () => {
+      vi.mocked(githubInfoService.getRepoDetails).mockResolvedValue({} as any);
+
+      renderHook(
+        () => useGetRepoDetails(null as unknown as string),
+        { wrapper: createWrapper() },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(githubInfoService.getRepoDetails).not.toHaveBeenCalled();
     });
   });
 

--- a/client/app/cross-modules/deployment/hooks/use-github-info.ts
+++ b/client/app/cross-modules/deployment/hooks/use-github-info.ts
@@ -141,18 +141,32 @@ export const useGetAllRepoBuilds = (
 export const useGetRepoDetails = (
   repoId: string,
   options?: {
-    refetchOnMount: boolean;
-    refetchOnWindowFocus: boolean;
+    refetchOnMount?: boolean;
+    refetchOnWindowFocus?: boolean;
     forceRefresh?: boolean;
+    branch?: string;
+    pageNumber?: number;
+    pageSize?: number;
   },
 ) => {
+  const { branch, pageNumber, pageSize } = options ?? {};
+
   return useQuery({
-    queryKey: ["repo-details", repoId],
+    // repoId stays in second position so ["repo-details", repoId] remains a prefix of
+    // this key and existing invalidateQueries calls keep matching it.
+    queryKey: ["repo-details", repoId, branch, pageNumber, pageSize],
     queryFn: () => {
       if (!repoId) {
         throw new Error("Repo ID is required");
       }
-      return githubInfoService.getRepoDetails(repoId);
+      // Only pass params when the caller actually asked for some, so callers that do
+      // not paginate keep the exact single-argument call they had before.
+      const hasParams =
+        branch !== undefined || pageNumber !== undefined || pageSize !== undefined;
+
+      return hasParams
+        ? githubInfoService.getRepoDetails(repoId, { branch, pageNumber, pageSize })
+        : githubInfoService.getRepoDetails(repoId);
     },
     enabled: !!repoId,
     staleTime: options?.forceRefresh ? 0 : 5 * 60 * 1000,

--- a/client/app/cross-modules/deployment/pages/repo-details.test.tsx
+++ b/client/app/cross-modules/deployment/pages/repo-details.test.tsx
@@ -96,6 +96,16 @@ const repoDetailsEmpty = {
   isSuccess: true,
 };
 
+// The repo's branch is "main"; this build is on another branch. That combination is what
+// the Details tab's single-item request makes dangerous, so it gets its own fixture.
+const repoDetailsForeignBranch = {
+  data: {
+    repo: { ...baseRepo },
+    build: [makeBuild({ branch: "some-other-branch", itemId: "foreign-1" })],
+  },
+  isSuccess: true,
+};
+
 describe("RepoDetails page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -631,5 +641,86 @@ describe("RepoDetails page", () => {
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Go Back" }));
     expect(navigateMock).toHaveBeenCalledWith(-1);
+  });
+
+  // ─── Pagination (#175) ──────────────────────────────────────────────────────
+
+  describe("build pagination", () => {
+    const okResponse = {
+      data: { repo: { ...baseRepo }, build: [makeBuild()] },
+      isSuccess: true,
+    };
+
+    const lastCallOptions = () => {
+      const calls = vi.mocked(useGetRepoDetails).mock.calls;
+      return calls[calls.length - 1][1] as
+        | { pageNumber?: number; pageSize?: number }
+        | undefined;
+    };
+
+    // H3
+    it("asks for a single build on the Details tab", () => {
+      currentTab = "details";
+      vi.mocked(useGetRepoDetails).mockReturnValue({
+        data: okResponse,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as never);
+
+      renderWithProviders(<RepoDetails />, {
+        route: "/app/deployment/repo/r1?tab=details",
+        nuqs: true,
+      });
+
+      expect(lastCallOptions()?.pageSize).toBe(1);
+      expect(lastCallOptions()?.pageNumber).toBe(1);
+    });
+
+    // H4
+    it("asks for thirty builds on the History tab", () => {
+      currentTab = "history";
+      vi.mocked(useGetRepoDetails).mockReturnValue({
+        data: okResponse,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as never);
+
+      renderWithProviders(<RepoDetails />, {
+        route: "/app/deployment/repo/r1?tab=history",
+        nuqs: true,
+      });
+
+      expect(lastCallOptions()?.pageSize).toBe(30);
+      expect(lastCallOptions()?.pageNumber).toBe(1);
+    });
+
+    // C3b: the silent-blank case. With a single-item request, a build whose branch differs
+    // from the repo's would be dropped by the page's branch filter, leaving the panel empty
+    // while the empty state (which tests the raw response) never renders either. The latest
+    // build is therefore taken from the raw, server-sorted response.
+    it("still shows the newest build when its branch differs from the repo's", () => {
+      currentTab = "details";
+      vi.mocked(useGetRepoDetails).mockReturnValue({
+        data: repoDetailsForeignBranch,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as never);
+
+      renderWithProviders(<RepoDetails />, {
+        route: "/app/deployment/repo/r1?tab=details",
+        nuqs: true,
+      });
+
+      // This panel renders `latestBuild?.repoUrl || "N/A"`, so the URL appearing proves
+      // latestBuild is populated. (Not asserting the absence of "N/A" anywhere on the
+      // page - other fields legitimately render it, e.g. a null commit.) The probe that
+      // reverts this derivation to the filtered list is what proves the assertion bites.
+      expect(
+        screen.getByText("https://github.com/acme/app"),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/client/app/cross-modules/deployment/pages/repo-details.tsx
+++ b/client/app/cross-modules/deployment/pages/repo-details.tsx
@@ -92,6 +92,11 @@ export interface IPipeline {
   customDeploymentURL?: string;
 }
 
+// Details shows a single build, History up to thirty. Named so each page size is one
+// fact rather than a literal buried in a ternary.
+const DETAILS_BUILD_PAGE_SIZE = 1;
+const HISTORY_BUILD_PAGE_SIZE = 30;
+
 export default function RepoDetails() {
   const navigate = useNavigate();
   const params = useParams();
@@ -123,6 +128,11 @@ export default function RepoDetails() {
     useInitialRepoDeployment();
   const [forceRefresh, setForceRefresh] = useState(false);
 
+  // The Details tab needs only the newest build; History shows up to thirty. Asking for
+  // one instead of the whole history is the point of this endpoint's pagination.
+  const buildPageSize =
+    tabId === "history" ? HISTORY_BUILD_PAGE_SIZE : DETAILS_BUILD_PAGE_SIZE;
+
   const {
     data: repoDetails,
     isLoading,
@@ -132,6 +142,8 @@ export default function RepoDetails() {
     refetchOnMount: true,
     refetchOnWindowFocus: false,
     forceRefresh: forceRefresh,
+    pageNumber: 1,
+    pageSize: buildPageSize,
   });
 
   useEffect(() => {
@@ -201,11 +213,17 @@ export default function RepoDetails() {
   }, [repoDetails, projectEnvironment, navigate]);
 
   const latestBuild = useMemo(() => {
-    if (!filteredBuilds) {
+    // Deliberately the RAW, server-sorted list rather than the branch-filtered one. With
+    // a single-item Details request, a build whose branch differs from the repo's would be
+    // dropped by that filter and leave this panel silently blank - the server has already
+    // narrowed to this repo and sorted newest-first, which is what "latest" means here.
+    const builds: IPipeline[] | undefined = repoDetails?.data?.build;
+
+    if (!builds) {
       return null;
     }
 
-    const latest = filteredBuilds.reduce<IPipeline | null>(
+    const latest = builds.reduce<IPipeline | null>(
       (latest, current) => {
         if (!latest) return current;
 
@@ -218,7 +236,7 @@ export default function RepoDetails() {
     );
 
     return latest;
-  }, [filteredBuilds]);
+  }, [repoDetails]);
 
   const handleGoBack = () => {
     navigate(scoped("deployment"));
@@ -477,6 +495,8 @@ export default function RepoDetails() {
               isDeploymentFlow={isDeploymentSettingsForDeploy}
               onDeploy={handleDeployFromSettings}
               isDeploying={isDeploying}
+              pageNumber={1}
+              pageSize={buildPageSize}
             />
           </Card>
         </div>
@@ -782,6 +802,8 @@ export default function RepoDetails() {
           isDeploymentFlow={isDeploymentSettingsForDeploy}
           onDeploy={handleDeployFromSettings}
           isDeploying={isDeploying}
+          pageNumber={1}
+          pageSize={buildPageSize}
         />
       </div>
     </>

--- a/client/app/cross-modules/deployment/services/github-info.service.test.ts
+++ b/client/app/cross-modules/deployment/services/github-info.service.test.ts
@@ -285,6 +285,58 @@ describe("GithubInfoService", () => {
       expect(http.get).toHaveBeenCalledWith(expectedUrl);
       expect(result).toEqual(mockResponse);
     });
+
+    // H6
+    it("puts branch, pageNumber and pageSize on the query string", async () => {
+      vi.mocked(http.get).mockResolvedValue({});
+
+      await githubInfoService.getRepoDetails(MOCK_REPO_ID, {
+        branch: "develop",
+        pageNumber: 2,
+        pageSize: 30,
+      });
+
+      const url = vi.mocked(http.get).mock.calls[0][0] as string;
+      expect(url).toContain(`RepoId=${encodeURIComponent(MOCK_REPO_ID)}`);
+      expect(url).toContain("branch=develop");
+      expect(url).toContain("pageNumber=2");
+      expect(url).toContain("pageSize=30");
+    });
+
+    it("encodes a branch name containing a slash", async () => {
+      vi.mocked(http.get).mockResolvedValue({});
+
+      await githubInfoService.getRepoDetails(MOCK_REPO_ID, {
+        branch: "feature/new-thing",
+      });
+
+      const url = vi.mocked(http.get).mock.calls[0][0] as string;
+      // Unencoded, the slash would read as a path segment rather than a value.
+      expect(url).toContain("branch=feature%2Fnew-thing");
+      expect(url).not.toContain("branch=feature/new-thing");
+    });
+
+    it("sends pageSize 0 rather than dropping it", async () => {
+      vi.mocked(http.get).mockResolvedValue({});
+
+      await githubInfoService.getRepoDetails(MOCK_REPO_ID, { pageSize: 0 });
+
+      // A truthiness check would omit this and silently fall back to the server default
+      // of 30 instead of the clamped 1 the caller would actually get.
+      const url = vi.mocked(http.get).mock.calls[0][0] as string;
+      expect(url).toContain("pageSize=0");
+    });
+
+    it("omits parameters that were not supplied", async () => {
+      vi.mocked(http.get).mockResolvedValue({});
+
+      await githubInfoService.getRepoDetails(MOCK_REPO_ID, { pageSize: 1 });
+
+      const url = vi.mocked(http.get).mock.calls[0][0] as string;
+      expect(url).toContain("pageSize=1");
+      expect(url).not.toContain("branch=");
+      expect(url).not.toContain("pageNumber=");
+    });
   });
 
   // ─── getCardRepoAndBranches ────────────────────────────────────────────────

--- a/client/app/cross-modules/deployment/services/github-info.service.ts
+++ b/client/app/cross-modules/deployment/services/github-info.service.ts
@@ -16,6 +16,12 @@ import {
   IManualDeploymentPayload,
 } from "@blocks-deployment/models/utils";
 
+export interface IRepoDetailsParams {
+  branch?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
 export class GithubInfoService {
   private readonly httpClient = serviceInstances.deploymentService;
   async verifyAuthorization(code: string): Promise<string> {
@@ -119,8 +125,27 @@ export class GithubInfoService {
     return this.httpClient.get(CLOUD_BUILD_ENDPOINTS.REPOS_LIST);
   }
 
-  async getRepoDetails(repoId: string): Promise<any> {
-    const url = `${CLOUD_BUILD_ENDPOINTS.REPO_DETAILS}?RepoId=${encodeURIComponent(repoId)}`;
+  /** Optional paging/filtering for repo-details. Omitting a field leaves the server
+   *  default in place; sending 0 is a real request that the server clamps. */
+  async getRepoDetails(
+    repoId: string,
+    params?: IRepoDetailsParams,
+  ): Promise<any> {
+    let url = `${CLOUD_BUILD_ENDPOINTS.REPO_DETAILS}?RepoId=${encodeURIComponent(repoId)}`;
+
+    // Each parameter is appended when DEFINED rather than when truthy: pageSize 0 is a
+    // meaningful request that the server clamps to 1, and a truthiness check would drop
+    // it and silently fall back to the server default instead.
+    if (params?.branch !== undefined) {
+      url += `&branch=${encodeURIComponent(params.branch)}`;
+    }
+    if (params?.pageNumber !== undefined) {
+      url += `&pageNumber=${encodeURIComponent(String(params.pageNumber))}`;
+    }
+    if (params?.pageSize !== undefined) {
+      url += `&pageSize=${encodeURIComponent(String(params.pageSize))}`;
+    }
+
     return this.httpClient.get(url);
   }
 

--- a/server/Api/Controllers/BuildController.cs
+++ b/server/Api/Controllers/BuildController.cs
@@ -16,6 +16,13 @@ namespace Api.Controllers;
 [Route("[controller]")]
 public class BuildController : ControllerBase
 {
+    // repo-details paging defaults. These are the controller's contract (H2); the hard
+    // bounds that keep the query safe live in the repository.
+    private const int DefaultPageNumber = 1;
+    private const int DefaultPageSize = 30;
+    public const string RepoNotFoundCode = "NOT_FOUND";
+    public const string RepoNotFoundMessage = "Repository not found";
+
     private readonly BuildService _buildService;
     private readonly IBuildRepository _buildRepository;
     private readonly IRepoRepository _repoRepository;
@@ -79,25 +86,46 @@ public class BuildController : ControllerBase
 
     [HttpGet("repo-details")]
     [ProtectedEndPoint("blocks-release::build::repo-details")]
-    public async Task<IActionResult> GetRepoDetails([FromQuery] string RepoId)
+    public async Task<IActionResult> GetRepoDetails(
+        [FromQuery] string RepoId,
+        [FromQuery] string? branch = null,
+        [FromQuery] int pageNumber = DefaultPageNumber,
+        [FromQuery] int pageSize = DefaultPageSize)
     {
         try
         {
-            var repoBuildList = await _repoRepository.GetRepoBuildList(RepoId);
+            // The repo is resolved first: when it does not exist the contract is an empty
+            // build array, so querying builds beforehand was both wasted work and the reason
+            // the not-found body could carry builds in it.
             var repo = await _repoRepository.GetRepo(RepoId);
             if (repo is null)
             {
-                return BadRequest(new BaseApiResponse()
+                // Built explicitly rather than as a BaseApiResponse: the inherited Errors
+                // property is an IDictionary<string, string>, and the contract for this
+                // endpoint calls for an array of { code, message }. The five envelope keys
+                // are reproduced exactly so the shape the client sees is unchanged.
+                return BadRequest(new
                 {
                     Data = new
                     {
-                        Repo = repo,
-                        Build = repoBuildList
+                        Repo = (Repo?)null,
+                        Build = Array.Empty<Build>()
+                    },
+                    Errors = new[]
+                    {
+                        new { Code = RepoNotFoundCode, Message = RepoNotFoundMessage }
                     },
                     IsSuccess = false,
-                    StatusCode = HttpStatusCode.BadRequest
+                    Message = RepoNotFoundMessage,
+                    StatusCode = (int)HttpStatusCode.BadRequest
                 });
             }
+
+            var repoBuildList = await _repoRepository.GetRepoBuildList(
+                RepoId,
+                branch,
+                pageNumber,
+                pageSize);
             return Ok(new BaseApiResponse()
             {
                 Data = new {

--- a/server/Devops.DomainService/Deployment/Interfaces/IRepoRepository.cs
+++ b/server/Devops.DomainService/Deployment/Interfaces/IRepoRepository.cs
@@ -12,7 +12,11 @@ public interface IRepoRepository
     public Task<Repo> GetRepo(string repoId, string tenantId);
     public Task<Repo?> GetRepoByBranch(string tenantId, string repoName, string branch);
     public Task<List<Repo>?> GetRepos();
-    public Task<List<Build>?> GetRepoBuildList(string RepoId);
+    public Task<List<Build>?> GetRepoBuildList(
+        string RepoId,
+        string? branch,
+        int pageNumber,
+        int pageSize);
     public Task SaveRepo(Repo repo);
     public Task<bool> UpdateRepo(RepoUpdateRequest repo);
     public Task<bool> UpdateRepo(RepoUpdateRequest repo,string tenantId);

--- a/server/Devops.DomainService/Deployment/RepositoryServices/RepoRepository.cs
+++ b/server/Devops.DomainService/Deployment/RepositoryServices/RepoRepository.cs
@@ -65,11 +65,50 @@ public class RepoRepository : IRepoRepository
         return await collection.Find(NotArchived).ToListAsync();
     }
 
-    public async Task<List<Build>?> GetRepoBuildList(string repoId)
+    // Page bounds live here rather than in the controller so that no caller, present or
+    // future, can drive this query with a negative skip or an unbounded limit.
+    private const int MinPageSize = 1;
+    private const int MaxPageSize = 100;
+    private const int DefaultPageSize = 30;
+
+    public async Task<List<Build>?> GetRepoBuildList(
+        string repoId,
+        string? branch,
+        int pageNumber,
+        int pageSize)
     {
         var collection = _dbContextProvider.GetCollection<Build>("Builds");
+
         var filter = Builders<Build>.Filter.Eq(r => r.RepoId, repoId);
-        return await collection.Find(filter).ToListAsync();
+        if (!string.IsNullOrWhiteSpace(branch))
+        {
+            filter &= Builders<Build>.Filter.Eq(r => r.Branch, branch);
+        }
+
+        var safePageNumber = Math.Max(1, pageNumber);
+        var safePageSize = Math.Clamp(pageSize, MinPageSize, MaxPageSize);
+
+        // Computed in long: (pageNumber - 1) * pageSize overflows int for page numbers near
+        // int.MaxValue and lands NEGATIVE, which is precisely the negative skip the clamp
+        // above exists to prevent. An absurd page is bounded to a page that simply has no
+        // documents rather than throwing.
+        var skip = (long)(safePageNumber - 1) * safePageSize;
+        var safeSkip = skip > int.MaxValue ? int.MaxValue : (int)skip;
+
+        // CreatedDate alone is not a total order - two builds can share a timestamp - so
+        // _id breaks the tie and makes paging deterministic. The raw field name is used
+        // rather than a mapped property so the sort does not depend on how the base entity
+        // maps its identifier.
+        var sort = Builders<Build>.Sort
+            .Descending(b => b.CreatedDate)
+            .Descending("_id");
+
+        return await collection
+            .Find(filter)
+            .Sort(sort)
+            .Skip(safeSkip)
+            .Limit(safePageSize)
+            .ToListAsync();
     }
 
     public async Task<IReadOnlyList<RepoWithBuildsResponse>> GetReposWithBuildsAsync(string projectId)

--- a/server/XUnitTest/Api/Controllers/BuildControllerTests.cs
+++ b/server/XUnitTest/Api/Controllers/BuildControllerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Api.Controllers;
 using Blocks.Genesis;
@@ -22,6 +23,13 @@ namespace XUnitTest.Api.Controllers
 {
     public class BuildControllerTests : IDisposable
     {
+        // Mirrors the wire format the client actually receives, so contract assertions are
+        // made against the serialized shape rather than against C# property names.
+        private static string Serialize(object value) =>
+            JsonSerializer.Serialize(
+                value,
+                new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
         private readonly DeploymentServiceFactory _f = new();
         private readonly Mock<IDataGatewayDeploymentService> _dataGateway = new();
 
@@ -61,7 +69,8 @@ namespace XUnitTest.Api.Controllers
         [Fact]
         public async Task GetRepoDetails_RepoFound_ReturnsOk()
         {
-            _f.RepoRepo.Setup(r => r.GetRepoBuildList("id")).ReturnsAsync(new List<Build>());
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList("id", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                       .ReturnsAsync(new List<Build>());
             _f.RepoRepo.Setup(r => r.GetRepo("id")).ReturnsAsync(new Repo());
             (await CreateController().GetRepoDetails("id")).Should().BeOfType<OkObjectResult>();
         }
@@ -69,7 +78,8 @@ namespace XUnitTest.Api.Controllers
         [Fact]
         public async Task GetRepoDetails_RepoNull_ReturnsBadRequest()
         {
-            _f.RepoRepo.Setup(r => r.GetRepoBuildList("id")).ReturnsAsync(new List<Build>());
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList("id", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                       .ReturnsAsync(new List<Build>());
             _f.RepoRepo.Setup(r => r.GetRepo("id")).ReturnsAsync((Repo)null);
             (await CreateController().GetRepoDetails("id")).Should().BeOfType<BadRequestObjectResult>();
         }
@@ -143,7 +153,7 @@ namespace XUnitTest.Api.Controllers
         [Fact]
         public async Task GetRepoDetails_ReturnsTheRepoWithItsBuildHistory()
         {
-            _f.RepoRepo.Setup(r => r.GetRepoBuildList("repo-1"))
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList("repo-1", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
                        .ReturnsAsync([new Build { ItemId = "build-1" }]);
             _f.RepoRepo.Setup(r => r.GetRepo("repo-1"))
                        .ReturnsAsync(new Repo { ItemId = "repo-1", RepoName = "web" });
@@ -159,19 +169,94 @@ namespace XUnitTest.Api.Controllers
         [Fact]
         public async Task GetRepoDetails_RejectsAnUnknownRepo()
         {
-            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>())).ReturnsAsync([]);
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                       .ReturnsAsync([]);
             _f.RepoRepo.Setup(r => r.GetRepo(It.IsAny<string>())).ReturnsAsync((Repo)null);
 
             var result = await CreateController().GetRepoDetails("gone");
 
             result.Should().BeOfType<BadRequestObjectResult>();
-            ((BaseApiResponse)((BadRequestObjectResult)result).Value).IsSuccess.Should().BeFalse();
+
+            // Asserted on the serialized payload rather than a typed property: the body is
+            // deliberately not a BaseApiResponse (its inherited Errors is a dictionary and
+            // the contract calls for an array), so only the wire shape is meaningful here.
+            var json = Serialize(((BadRequestObjectResult)result).Value);
+            json.Should().Contain("\"isSuccess\":false");
+            json.Should().Contain("\"statusCode\":400");
+            json.Should().Contain("\"repo\":null");
+            json.Should().Contain("\"build\":[]");
+            json.Should().Contain("\"message\":\"Repository not found\"");
+            json.Should().Contain("\"errors\":[{\"code\":\"NOT_FOUND\",\"message\":\"Repository not found\"}]");
+        }
+
+        // C5: an existing repo with no builds is a 200 with an empty array, NOT a 400 and
+        // not a null repo, and the rest of the success envelope has to stay intact.
+        [Fact]
+        public async Task GetRepoDetails_ValidRepoWithNoBuilds_Returns200AndAnEmptyBuildArray()
+        {
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                       .ReturnsAsync([]);
+            _f.RepoRepo.Setup(r => r.GetRepo("repo-1"))
+                       .ReturnsAsync(new Repo { ItemId = "repo-1", RepoName = "org/web" });
+
+            var result = await CreateController().GetRepoDetails("repo-1");
+
+            result.Should().BeOfType<OkObjectResult>();
+            var json = Serialize(((OkObjectResult)result).Value);
+            json.Should().Contain("\"isSuccess\":true");
+            json.Should().Contain("\"build\":[]");
+            json.Should().Contain("\"errors\":null");
+            json.Should().Contain("\"message\":null");
+            json.Should().Contain("org/web");
+        }
+
+        // H2: the defaults are part of the contract, so they are asserted on the arguments
+        // the repository actually received rather than inferred from the response.
+        [Fact]
+        public async Task GetRepoDetails_WithoutPagingArguments_UsesPageOneAndThirty()
+        {
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                       .ReturnsAsync([]);
+            _f.RepoRepo.Setup(r => r.GetRepo("repo-1")).ReturnsAsync(new Repo { ItemId = "repo-1" });
+
+            await CreateController().GetRepoDetails("repo-1");
+
+            _f.RepoRepo.Verify(r => r.GetRepoBuildList("repo-1", null, 1, 30), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetRepoDetails_PassesBranchAndPagingStraightThrough()
+        {
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                       .ReturnsAsync([]);
+            _f.RepoRepo.Setup(r => r.GetRepo("repo-1")).ReturnsAsync(new Repo { ItemId = "repo-1" });
+
+            await CreateController().GetRepoDetails("repo-1", "develop", 3, 5);
+
+            _f.RepoRepo.Verify(r => r.GetRepoBuildList("repo-1", "develop", 3, 5), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetRepoDetails_DoesNotQueryBuildsForARepoThatDoesNotExist()
+        {
+            _f.RepoRepo.Setup(r => r.GetRepo(It.IsAny<string>())).ReturnsAsync((Repo)null);
+
+            await CreateController().GetRepoDetails("gone");
+
+            _f.RepoRepo.Verify(
+                r => r.GetRepoBuildList(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+                Times.Never);
         }
 
         [Fact]
         public async Task GetRepoDetails_TurnsARepositoryFailureIntoABadRequest()
         {
-            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>()))
+            // The repo is resolved first now, so this has to succeed for the build query
+            // to be reached at all - otherwise the test would pass on the not-found path
+            // and prove nothing about failure handling.
+            _f.RepoRepo.Setup(r => r.GetRepo(It.IsAny<string>()))
+                       .ReturnsAsync(new Repo { ItemId = "repo-1" });
+            _f.RepoRepo.Setup(r => r.GetRepoBuildList(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
                        .ThrowsAsync(new TimeoutException("mongo unreachable"));
 
             var result = await CreateController().GetRepoDetails("repo-1");

--- a/server/XUnitTest/Integration/RepoRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/RepoRepositoryIntegrationTests.cs
@@ -96,8 +96,193 @@ namespace XUnitTest.Integration
             var builds = _fixture.Collection<Build>("Builds");
             await builds.InsertOneAsync(new Build { ItemId = Guid.NewGuid().ToString("N"), RepoId = repoId, RepoName = "org/r" });
 
-            var result = await CreateRepo().GetRepoBuildList(repoId);
+            var result = await CreateRepo().GetRepoBuildList(repoId, null, 1, 30);
             result.Should().HaveCount(1);
+        }
+
+        private static Build NewBuild(string repoId, string branch, DateTime createdDate,
+                                      string itemId = null) => new()
+        {
+            ItemId = itemId ?? Guid.NewGuid().ToString("N"),
+            RepoId = repoId,
+            RepoName = "org/r",
+            Branch = branch,
+            CreatedDate = createdDate
+        };
+
+        // H1: only the requested repo's builds come back. The unrelated repo deliberately
+        // shares the requested BRANCH - without that, an implementation filtering only by
+        // branch would pass this test.
+        [Fact]
+        public async Task GetRepoBuildList_ReturnsOnlyTheRequestedRepo_EvenWhenAnotherRepoSharesTheBranch()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var otherRepoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var now = DateTime.UtcNow;
+
+            await builds.InsertManyAsync(new[]
+            {
+                NewBuild(repoId, "main", now.AddMinutes(-1), "mine-1"),
+                NewBuild(repoId, "main", now.AddMinutes(-2), "mine-2"),
+                NewBuild(otherRepoId, "main", now, "theirs-newest")
+            });
+
+            var result = await CreateRepo().GetRepoBuildList(repoId, "main", 1, 30);
+
+            result.Select(b => b.ItemId).Should().BeEquivalentTo(new[] { "mine-1", "mine-2" });
+        }
+
+        // H1b: an omitted branch means NO branch filtering. Without this, "filters by
+        // branch when asked" and "always filters by branch" are indistinguishable.
+        [Fact]
+        public async Task GetRepoBuildList_WithoutABranch_ReturnsEveryBranch()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var now = DateTime.UtcNow;
+
+            await builds.InsertManyAsync(new[]
+            {
+                NewBuild(repoId, "main", now.AddMinutes(-1), "on-main"),
+                NewBuild(repoId, "develop", now.AddMinutes(-2), "on-develop")
+            });
+
+            var all = await CreateRepo().GetRepoBuildList(repoId, null, 1, 30);
+            all.Select(b => b.ItemId).Should().BeEquivalentTo(new[] { "on-main", "on-develop" });
+
+            var onlyMain = await CreateRepo().GetRepoBuildList(repoId, "main", 1, 30);
+            onlyMain.Select(b => b.ItemId).Should().BeEquivalentTo(new[] { "on-main" });
+        }
+
+        // H1: newest first, and paging walks backwards through time.
+        [Fact]
+        public async Task GetRepoBuildList_SortsNewestFirstAndPagesThroughTheHistory()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var now = DateTime.UtcNow;
+
+            // Inserted oldest-first so natural order is the opposite of the expected order.
+            await builds.InsertManyAsync(new[]
+            {
+                NewBuild(repoId, "main", now.AddMinutes(-5), "b5"),
+                NewBuild(repoId, "main", now.AddMinutes(-4), "b4"),
+                NewBuild(repoId, "main", now.AddMinutes(-3), "b3"),
+                NewBuild(repoId, "main", now.AddMinutes(-2), "b2"),
+                NewBuild(repoId, "main", now.AddMinutes(-1), "b1")
+            });
+
+            var sut = CreateRepo();
+
+            (await sut.GetRepoBuildList(repoId, null, 1, 2))
+                .Select(b => b.ItemId).Should().Equal("b1", "b2");
+            (await sut.GetRepoBuildList(repoId, null, 2, 2))
+                .Select(b => b.ItemId).Should().Equal("b3", "b4");
+            (await sut.GetRepoBuildList(repoId, null, 3, 2))
+                .Select(b => b.ItemId).Should().Equal("b5");
+            (await sut.GetRepoBuildList(repoId, null, 1, 1))
+                .Select(b => b.ItemId).Should().Equal("b1");
+        }
+
+        // H1c: CreatedDate is not a total order. Two builds share a timestamp and are
+        // inserted so that natural order DISAGREES with _id descending - otherwise
+        // removing the tiebreaker could still produce the expected order by accident.
+        [Fact]
+        public async Task GetRepoBuildList_BreaksCreatedDateTiesById()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var sameInstant = DateTime.UtcNow.AddMinutes(-1);
+
+            await builds.InsertManyAsync(new[]
+            {
+                NewBuild(repoId, "main", sameInstant, "aaa-lowest-id"),
+                NewBuild(repoId, "main", sameInstant, "zzz-highest-id")
+            });
+
+            var result = await CreateRepo().GetRepoBuildList(repoId, null, 1, 30);
+
+            result.Select(b => b.ItemId).Should().Equal("zzz-highest-id", "aaa-lowest-id");
+        }
+
+        // C2: clamping, with enough documents seeded that an UNCLAMPED implementation
+        // would visibly return a different count.
+        [Fact]
+        public async Task GetRepoBuildList_ClampsPageSizeAboveTheMaximum()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var now = DateTime.UtcNow;
+
+            await builds.InsertManyAsync(Enumerable.Range(0, 101)
+                .Select(i => NewBuild(repoId, "main", now.AddSeconds(-i))));
+
+            var result = await CreateRepo().GetRepoBuildList(repoId, null, 1, 5000);
+
+            result.Should().HaveCount(100);
+        }
+
+        [Fact]
+        public async Task GetRepoBuildList_ClampsPageSizeBelowTheMinimum()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var now = DateTime.UtcNow;
+
+            await builds.InsertManyAsync(new[]
+            {
+                NewBuild(repoId, "main", now.AddMinutes(-1), "min-newest"),
+                NewBuild(repoId, "main", now.AddMinutes(-2), "min-older")
+            });
+
+            var result = await CreateRepo().GetRepoBuildList(repoId, null, 1, 0);
+
+            result.Select(b => b.ItemId).Should().Equal("min-newest");
+        }
+
+        [Fact]
+        public async Task GetRepoBuildList_ClampsANegativePageNumberToTheFirstPage()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            var now = DateTime.UtcNow;
+
+            await builds.InsertManyAsync(new[]
+            {
+                NewBuild(repoId, "main", now.AddMinutes(-1), "neg-newest"),
+                NewBuild(repoId, "main", now.AddMinutes(-2), "neg-older")
+            });
+
+            var result = await CreateRepo().GetRepoBuildList(repoId, null, -5, 1);
+
+            result.Select(b => b.ItemId).Should().Equal("neg-newest");
+        }
+
+        // C2: (pageNumber - 1) * pageSize overflows int near the maximum and lands
+        // NEGATIVE, which is exactly the negative skip the clamp exists to prevent. An
+        // absurd page must come back empty rather than throwing or wrapping around.
+        [Fact]
+        public async Task GetRepoBuildList_AnAbsurdPageNumberReturnsNothingRatherThanThrowing()
+        {
+            var repoId = Guid.NewGuid().ToString("N");
+            var builds = _fixture.Collection<Build>("Builds");
+            await builds.InsertOneAsync(NewBuild(repoId, "main", DateTime.UtcNow));
+
+            var result = await CreateRepo().GetRepoBuildList(repoId, null, int.MaxValue, 30);
+
+            result.Should().BeEmpty();
+        }
+
+        // C5 at the repository level: a repo with no builds is an empty list, not null.
+        [Fact]
+        public async Task GetRepoBuildList_RepoWithNoBuilds_ReturnsEmptyNotNull()
+        {
+            var result = await CreateRepo().GetRepoBuildList(
+                Guid.NewGuid().ToString("N"), null, 1, 30);
+
+            result.Should().NotBeNull();
+            result.Should().BeEmpty();
         }
 
         [Fact]


### PR DESCRIPTION
Closes #175.

`GET /build/repo-details` now takes `branch`, `pageNumber` and `pageSize` and returns builds newest-first, instead of returning a repo's entire build history on every request. The Details tab asks for one build; History asks for thirty.

## Backend

- **`RepoRepository.GetRepoBuildList`** filters by `RepoId` (and `Branch` when one is supplied), sorts by `CreatedDate desc, _id desc`, then skips and limits. The `_id` tiebreaker is load-bearing: `CreatedDate` is not a total order, and two builds sharing a timestamp make paging non-deterministic without it. The sort uses the raw `_id` field name so it does not depend on how the base entity maps its identifier.
- **Page bounds live in the repository**, not the controller, so no caller — present or future — can drive this query with a negative skip or an unbounded limit. The controller keeps the `1`/`30` defaults that are its contract.
- **The skip is computed in `long`.** `(pageNumber - 1) * pageSize` is `int` arithmetic and overflows *negative* for page numbers near `int.MaxValue`, even after clamping the page number — which is precisely the negative skip C2 exists to prevent. An absurd page now returns an empty result rather than throwing.
- **The controller resolves the repo first.** It previously queried builds before knowing whether the repo existed: wasted work, and the reason the not-found body could carry builds in it. Not-found now returns `build: []` with the error contract from §3.

## Frontend

- The service appends each parameter when **defined** rather than when truthy, so `pageSize: 0` is actually sent and clamped server-side instead of silently falling back to the default of 30.
- The query key is `["repo-details", repoId, branch, pageNumber, pageSize]` — `repoId` stays in second position so `["repo-details", repoId]` remains a working invalidation prefix, which is in the must-not-break list.
- The settings modal forwards the caller's paging. It is mounted even while closed and always calls the hook, so without this the Details tab would fire a *second* request (page size 1 for the page, 30 for the modal). It only ever reads `data.repo`.

## Two deviations, both deliberate

**1. The latest build now comes from the raw response, not the branch-filtered list.**

The page filters builds client-side on `build.branch === repo.branch`. With a single-item request, a build whose branch differs from the repo's is dropped by that filter — and the empty state does not catch it, because that condition tests the *raw* `data.build.length`. The result would be a silently blank panel. `latestBuild` is therefore derived from the raw, server-sorted response: the server has already narrowed to this `RepoId` and sorted newest-first. For any data the current code can produce these are the same record, so nothing changes in practice.

**2. No branch is sent from the page, and no index is created.**

I first planned to send the project environment as the branch. That is wrong: `CloudBuildConstants.cs` maps branch → environment (`main` → `prod`), so a production project would have asked for a branch named "prod" while its builds say "main", and the tab would have gone empty. The `branch` parameter is implemented end to end as specified, but the page does not send one — no acceptance criterion requires it, and deviation 1 removes the filtering loss that sending one was meant to address.

§3 permits a compound index. Permitted is not required, and creating a production index is a database change I will not make unattended. Recommended for a DBA:

```
db.Builds.createIndex({ RepoId: 1, Branch: 1, CreatedDate: -1, _id: -1 })
```

Worth noting that this shape serves the *branchless* query less well, since `Branch` is an unbound middle key — and the branchless query is the one the UI actually issues. `{ RepoId: 1, CreatedDate: -1, _id: -1 }` may be the better single index.

## A question for the spec author

Should a `Build`'s branch be allowed to diverge from its `Repo`'s? Today all three creation paths copy `repo.Branch`, and a repo record is per-branch — so `RepoId` effectively implies branch. But nothing enforces it: `SaveBuild` persists whatever branch the request carries, and `UpdateRepo` can replace a repo's branch wholesale after builds exist. Deviation 1 makes the UI behave sensibly either way, but the underlying question is worth settling.

## Verification

Backend **681 passed, 0 failed** (baseline 668 — this branch was already green, so every failure would be mine). Frontend **764 passed across 119 files** (baseline 750). Type-check clean. Lint adds **zero** new problems — each changed file was linted against its committed version and the counts are identical.

Coverage on changed code: the changed regions of `RepoRepository.cs` and `BuildController.cs` are at **100%**; frontend files run 86.2%–95.8% line coverage.

Sixteen mutations were applied to confirm the tests actually bite — dropping the limit, dropping the skip, reversing the sort, removing the `_id` tiebreaker, removing the lower clamp, reverting the skip to `int` arithmetic, making the branch filter unconditional, changing the controller defaults, stripping the error array, leaking builds into the not-found body, reordering the query key, switching the service to a truthiness check, leaving the branch unencoded, giving Details the wrong page size, reverting the latest-build derivation, and making the modal ignore its paging. Every one was caught by a named test.

One note on that: the first backend probe run reported results I had to throw away. Restoring files with `copy2` preserved their original timestamps, so MSBuild considered the assembly up to date and skipped rebuilding — meaning probes were running against a binary that still contained the *previous* mutation. The re-run stamps the mtime on every write and asserts a green baseline before and after; the corrected results are the ones quoted above.
